### PR TITLE
Adjustments (not relevant for passing)

### DIFF
--- a/rank04/q3/argo/passing_solution/argo.c
+++ b/rank04/q3/argo/passing_solution/argo.c
@@ -18,6 +18,9 @@ int		g_error_no_key = 0;
 
 int	argo(json *dst, FILE *stream)
 {
+	if (!stream)
+		return (-1);
+	
 	*dst = parse_json(stream);
 	if (g_error_no_key)
 	{

--- a/rank04/q3/argo/passing_solution/argo.c
+++ b/rank04/q3/argo/passing_solution/argo.c
@@ -20,7 +20,7 @@ int	argo(json *dst, FILE *stream)
 {
 	if (!stream)
 		return (-1);
-	
+
 	*dst = parse_json(stream);
 	if (g_error_no_key)
 	{
@@ -137,12 +137,12 @@ char	*parse_string(FILE *stream)
 		cur_char = getc(stream);
 		if (cur_char == '\\')
 		{
-			cur_char = getc(stream);
-			if (cur_char != '\\' && cur_char != '\"')
+			if (peek(stream) != '\\' && peek(stream) != '\"')
 			{
 				set_g_error();
 				return (res);
 			}
+			cur_char = getc(stream);
 		}
 		res[str_len - 1] = cur_char;
 	}

--- a/rank04/q3/argo/passing_solution/main.c
+++ b/rank04/q3/argo/passing_solution/main.c
@@ -1,20 +1,23 @@
 #include "argo.h"
 
-void free_json(json j) {
-    switch (j.type) {
-        case MAP:
-            for (size_t i = 0; i < j.map.size; i++) {
-            free(j.map.data[i].key);
-            free_json(j.map.data[i].value);
-        }
-        free(j.map.data);
-        break;
-        case STRING:
-            free(j.string);
-            break;
-        default:
-            break;
-    }
+void	free_json(json j)
+{
+	switch (j.type) {
+		case MAP:
+			for (size_t i = 0; i < j.map.size; i++)
+			{
+				free(j.map.data[i].key);
+				free_json(j.map.data[i].value);
+			}
+			free(j.map.data);
+			break;
+		case STRING:
+			free(j.string);
+			break;
+		default:
+			printf("inside default\n");
+			break;
+	}
 }
 
 void serialize(json j) {
@@ -50,11 +53,8 @@ int main(int ac, char **av) {
         return 1;
     char *filename = av[1];
     FILE *stream = fopen(filename, "r");
-    json file;
-    if (!stream) {
-        perror("fmemopen");
-        return 1;
-    }
+    json file = { .type = 42 }; // set to invalid type in order to invoke default case in free_json()
+
     if (argo(&file, stream) != 1) {
         free_json(file);
         return 1;


### PR DESCRIPTION
regarding **[ARGO (passing solution)]
Rank4 / Q3**

- solution before never invoked the 'default case' of `free_json` (invalid type --> json wasn't assigned by argo)
- changed so that program doesn't return 'early' when` fopen` fails, but let it run until  `free_json`

**BEFORE:**
```bash
$> ./a.out '1'
>fmemopen: No such file or directory
```

**AFTER:**
```bash
$> ./a.out '1'
> inside default
```

/////////////////

- solution before did not report the correct 'unexpected token' when escaping an invalid char (everything but '\' and '"'), but skipped the actual 'invalid escaped char'   

**BEFORE:**
```bash
$> echo -n '"bonj\2our"' | ./a.out /dev/stdin
> Unexpected token 'o'
```

**AFTER:**
```bash
$> echo -n '"bonj\2our"' | ./a.out /dev/stdin
> Unexpected token '2'
```
